### PR TITLE
Add request pathname assertion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,32 @@ Assertion.prototype.set = function(key, value){
 };
 
 /**
+ * Assert the request `path`.
+ *
+ * Example:
+ *
+ *      assertion(integration)
+ *        .track({ event: 'my event' })
+ *        .pathname('/track')
+ *        .expects(200, done);
+ *
+ * @param {Object} obj
+ * @return {Assertion}
+ * @api private
+ */
+
+Assertion.prototype.pathname = function(value){
+  var self = this;
+
+  this.assertions.push(function(req){
+    var pathname = req.req.path.split('?')[0];
+    return utils.equals(pathname, value);
+  });
+
+  return this;
+};
+
+/**
  * Add query.
  *
  * Example:

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -320,6 +320,16 @@ describe('Assertion', function(){
     })
   })
 
+  describe('.pathname(value)', function(){
+    it('should assert request path', function(done){
+      Assertion(segment)
+        .set('key', 'baz')
+        .track({})
+        .pathname('/json/track')
+        .expects(200, done);
+    });
+  });
+
   describe('.expects(value)', function(done){
     it('should assert status correctly', function(done){
       Assertion(segment)


### PR DESCRIPTION
Kinda handy for ensuring the correct pathname is used when integrations use varying paths for different message types. For example: https://github.com/segmentio/integrations/blob/master/lib/outbound/index.js#L53

cc: @yields 
