### PR TITLE
Query

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -314,7 +314,8 @@ Assertion.prototype.pathname = function(value){
  * @api private
  */
 
-Assertion.prototype.query = function(key, value){
+Assertion.prototype.query = function(key, value, parse){
+  var noop = function(_){ return _; };
   var self = this;
 
   // obj
@@ -324,15 +325,29 @@ Assertion.prototype.query = function(key, value){
   }
 
   // key, value
-  this.q[key] = value;
+  this.q[key] = [value, parse || noop];
 
   if (!this.pushedQueryAssertion) {
     this.pushedQueryAssertion = true;
     this.assertions.push(function(req){
       var query = req.req.path.split('?')[1];
       if (!query) return new Error('expected request to include query string but no query string was found');
-      var expected = self.q;
+
+      // actual
       var actual = qs.parse(query);
+
+      // expected
+      var expected = Object.keys(self.q)
+        .reduce(function(_, key){
+          var arr = self.q[key];
+          var expected = arr.shift();
+          var parse = arr.shift();
+          actual[key] = parse(actual[key]);
+          _[key] = expected;
+          return _;
+        }, {});
+
+      // compare
       return utils.equals(actual, expected);
     });
   }

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -346,7 +346,7 @@ describe('Assertion', function(){
         .set({ key: 'baz' })
         .identify({})
         .query('foo', [1], JSON.parse)
-        .end(error('expected { foo: [ 1 ] } but got { foo: [1, 2, 3] }', done));
+        .end(error('expected { foo: [ 1 ] } but got { foo: [ 1, 2, 3 ] }', done));
     });
   });
 


### PR DESCRIPTION
this allows you to pass `parse` function for each key, to allow less verbose testing.

so this:

``` js
    it('should map screen calls correctly', function(done){
      var screen = {
        name: 'name',
        timestamp: new Date()
      };
      var event = JSON.stringify({
        time: screen.timestamp.getTime(),
        user_properties: {},
        event_type: 'Viewed name Screen',
        event_properties: {
          name: 'name'
        }
      });

      test
        .set(settings)
        .screen(screen)
        .query({
          api_key: settings.apiKey,
          event: event
        })
        .expects(200, done);
    });
```

becomes (note the `JSON.parse`.)

``` js
    it('should map screen calls correctly', function(done){
      var json = test.fixture('screen-basic');
      test
        .set(settings)
        .screen(json.input)
        .query('api_key', settings.apiKey)
        .query('event', json.output, JSON.parse)
        .expects(200, done);
    });
```
