### PR TITLE
Ignore recursively

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,10 +169,30 @@ Assertion.prototype.maps = function(fixture, settings, options){
   actual = JSON.parse(JSON.stringify(actual));
 
   if (options.ignored) {
-    options.ignored.map(function(name) {
-      delete actual[name]
-      assert(!expected[name], "ignored expected value:" + name);
-    });
+    // Recursively strip all keys given in options.ignored from actual, and from
+    // all objects contained in or nested under actual.
+    var stripIgnoredFromResult = function(obj) {
+      // If obj is an array: strip out any ignored values and recurse if necessary
+      if (obj instanceof Array) {
+        for (var i = obj.length - 1; i >= 0; i--) {
+          if (options.ignored.indexOf(obj[i]) != -1) {
+            obj.splice(i, 1);
+          } else if (typeof obj[i] === 'object') { // recurse on contained objs
+            stripIgnoredFromResult(obj[i]);
+          }
+        }
+      } else {
+        // Otherwise, basically do the same thing (but with object syntax)
+        for (var prop in obj) {
+          if (options.ignored.indexOf(prop) != -1) {
+            delete obj[prop];
+          } else if (typeof obj[prop] === 'object') { // recurse on contained objs
+            stripIgnoredFromResult(obj[prop]);
+          }
+        }
+      }
+    };
+    stripIgnoredFromResult(actual);
   }
 
   // compare

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -64,7 +64,7 @@ describe('Assertion', function(){
     });
   });
 
-  describe('.maps(name, settings)', function(){
+  describe('.maps(name, settings, options)', function(){
     beforeEach(function(){
       var map = { identify: identify };
       Segment = integration('Segment').mapper(map);
@@ -98,6 +98,25 @@ describe('Assertion', function(){
 
     it('should not throw an error when only differing value ignored', function(){
       Assertion(segment, __dirname).maps('not-equal', {}, {'ignored': ['timestamp']});
+    });
+
+    it('should not throw an error when values ignored recursively', function(){
+      Assertion(segment, __dirname).maps('ignore-array-keys', {}, {'ignored': ['color', 'timestamp']});
+    });
+
+    it('should throw an error when ignoring values doesnt catch all errors', function(){
+      var err;
+
+      try {
+        Assertion(segment, __dirname).maps('ignore-array-keys', {}, {'ignored': ['house', 'timestamp']});
+      } catch (e) {
+        err = e;
+      }
+
+      assert(err, 'expected integration to throw');
+      assert(err.actual, 'err must have .actual');
+      assert(err.expected, 'err must have .expected');
+      assert.equal(true, err.showDiff, 'err must have .showDiff = true');
     });
 
     it('should merge settings when available', function(){

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -96,6 +96,10 @@ describe('Assertion', function(){
       assert.equal(true, err.showDiff, 'err must have .showDiff = true');
     });
 
+    it('should not throw an error when only differing value ignored', function(){
+      Assertion(segment, __dirname).maps('not-equal', {}, {'ignored': ['timestamp']});
+    });
+
     it('should merge settings when available', function(){
       segment.mapper.identify = function(_, s){ return s; };
       Assertion(segment, __dirname).maps('settings', {

--- a/test/fixtures/ignore-array-keys.json
+++ b/test/fixtures/ignore-array-keys.json
@@ -1,0 +1,50 @@
+{
+  "input": {
+    "type": "identify",
+    "userId": "user-id",
+    "properties": {
+      "prop": true
+    },
+    "otherStuff": [
+      {
+        "house": "stark",
+        "color": "white"
+      },
+      {
+        "house": "lannister",
+        "color": "red"
+      },
+      {
+        "house": "baratheon",
+        "color": "yellow"
+      },
+      {
+        "house": "tyrell",
+        "color": "green"
+      }
+    ],
+    "rawArrayKeys": ["color", "others"]
+  },
+  "output": {
+    "type": "identify",
+    "userId": "user-id",
+    "properties": {
+      "prop": true
+    },
+    "otherStuff": [
+      {
+        "house": "stark"
+      },
+      {
+        "house": "lannister"
+      },
+      {
+        "house": "baratheon"
+      },
+      {
+        "house": "tyrell"
+      }
+    ],
+    "rawArrayKeys": ["others"]
+  }
+}


### PR DESCRIPTION
first, add a test for our old ignore-key functionality.
then add the ability to ignore keys recursively while testing an integration (with a test for that as well).