### PR TITLE
use modern ecommerce spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "integration tester",
   "version": "1.1.0",
   "dependencies": {
-    "analytics-events": "^1.0.0",
+    "analytics-events": "^2.0.0",
     "clone-component": "^0.2.2",
     "ms": "^0.6.2",
     "qs": "^1.2.1",

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -127,9 +127,14 @@ describe('Assertion', function(){
       });
     });
 
-    it('should map ecommerce events', function(){
-      segment.mapper.completedOrder = function(t){ return t.properties(); };
+    it('should map actionObject ecommerce events', function(){
+      segment.mapper.orderCompleted = function(t){ return t.properties(); };
       Assertion(segment, __dirname).maps('ecommerce');
+    });
+
+    it('should map objectAction ecommerce events', function(){
+      segment.mapper.orderCompleted = function(t){ return t.properties(); };
+      Assertion(segment, __dirname).maps('ecommerce-object-action');
     });
 
     it('should throw when the mapper is missing', function(){
@@ -144,11 +149,6 @@ describe('Assertion', function(){
       var a = Assertion(segment, __dirname);
       var fixture = a.maps.bind(a, 'equal');
       throws(fixture, 'integration.mapper.identify() returned "null"')
-    });
-
-    it('should map ecommerce events', function(){
-      segment.mapper.completedOrder = function(t){ return t.properties(); };
-      Assertion(segment, __dirname).maps('ecommerce');
     });
 
     it('should throw when the mapper is missing', function(){

--- a/test/fixtures/ecommerce-object-action.json
+++ b/test/fixtures/ecommerce-object-action.json
@@ -1,0 +1,12 @@
+{
+  "input": {
+    "type": "track",
+    "event": "Completed Order",
+    "properties": {
+      "orderId": "order-id"
+    }
+  },
+  "output": {
+    "orderId": "order-id"
+  }
+}

--- a/test/fixtures/ecommerce-object-action.json
+++ b/test/fixtures/ecommerce-object-action.json
@@ -1,7 +1,7 @@
 {
   "input": {
     "type": "track",
-    "event": "Completed Order",
+    "event": "Order Completed",
     "properties": {
       "orderId": "order-id"
     }


### PR DESCRIPTION
@hankim813 😭 😭 😭 😭 😭

- [ ] release as 2.x
- [ ] use in facebook-app-events
- [ ] use in tune v2

---

- [ ] do the same thing for analytics.js-integration tester   
  - [ ] use in ajs-int-adobe-analytics v2
  - [ ] pin to 2.x in each of the analytics.js integrations that we're migrating to support objectAction (after the browserify migration) @wcjohnson11 has PRs open for those that we should bump the tester in as well