### PR TITLE
Ensure there are no assertions on requests that weren't made INT-551

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
 machine:
   node:
     version: 0.10.26
+
+dependencies:
+  pre:
+    - npm install -g npm@2

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,6 +65,7 @@ function Assertion(integration, dirname){
   this.dirname = dirname;
   this.assertions = {};
   this.reqIndex = 0;
+  this.maxIndex = 0;
   this.reqs = [];
   this.q = {};
 
@@ -96,6 +97,7 @@ function Assertion(integration, dirname){
 Assertion.prototype.request = function(i){
   assert(0 <= i, 'request index must be >= 0, got "' + i + '"');
   this.reqIndex = parseInt(i);
+  this.maxIndex = Math.max(this.maxIndex, this.reqIndex);
   return this;
 };
 
@@ -597,6 +599,10 @@ Assertion.prototype.end = function(fn){
   integration[type](msg, function(err, responses){
     if (err) return fn(err, responses);
     if (!Array.isArray(responses)) responses = [responses];
+    if (self.maxIndex + 1 > self.reqs.length) {
+      return fn(new Error('Assertions made for ' + (self.maxIndex + 1)
+                          + ' requests but only ' + self.reqs.length + ' requests were made'));
+    }
 
     // all requests
     var err = self.assert('all');

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -685,6 +685,28 @@ describe('Assertion', function(){
         test.end(done);
       });
 
+      it('should error if there are assertions on requests that were not made', function(done) {
+        var test = Assertion(segment);
+        var date = new Date;
+
+        test.set('key', 'baz');
+        test.set('times', 3);
+        test.requests(3);
+
+        // message
+        test.track({
+          userId: 'user-id',
+          timestamp: date,
+        });
+
+        test
+          .request(3)
+          .query({ foo: '3' })
+          .expects(200);
+
+        test.end(error('Assertions made for 4 requests but only 3 requests were made', done));
+      });
+
       // figure out proper behavior
       it.skip('should abort on mismatch', function(done){
         var test = Assertion(segment);


### PR DESCRIPTION
This will force an error if you call `.request(1)` but only send 1 request (requests are 0-indexed)