### PR TITLE
Allowing asserting that no requests were made

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,7 @@ function Assertion(integration, dirname){
   this.dirname = dirname;
   this.assertions = {};
   this.reqIndex = 0;
-  this.maxIndex = 0;
+  this.maxIndex = -1;
   this.reqs = [];
   this.q = {};
 
@@ -97,7 +97,6 @@ function Assertion(integration, dirname){
 Assertion.prototype.request = function(i){
   assert(0 <= i, 'request index must be >= 0, got "' + i + '"');
   this.reqIndex = parseInt(i);
-  this.maxIndex = Math.max(this.maxIndex, this.reqIndex);
   return this;
 };
 
@@ -423,6 +422,10 @@ Assertion.prototype.pathname = function(value){
 Assertion.prototype.push = function(i, fn){
   if (1 == arguments.length) fn = i, i = this.reqIndex;
   (this.assertions[i] = this.assertions[i] || []).push(fn);
+  var index = Number(i);
+  if (!Number.isNaN(index)) {
+    this.maxIndex = Math.max(this.maxIndex, index);
+  }
   return this;
 };
 

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -626,6 +626,15 @@ describe('Assertion', function(){
           .requests(2)
           .end(done);
       });
+
+      it('should allow checking for no requests to be sent', function(done) {
+        Assertion(segment)
+          .set('key', 'baz')
+          .set('times', 0)
+          .track({ userId: '1' })
+          .requests(0)
+          .end(done);
+      });
     });
 
     describe('.request(n)', function(){


### PR DESCRIPTION
If you were attempting to test that no requests were made `.requests(0)` it would error out saying that assertions were made for 1 request, but only 0 requests were made.