### PR TITLE
circle: test with node 6

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,13 @@
 machine:
   node:
-    version: 0.10.26
+    version: 6
 
 dependencies:
   pre:
-    - npm install -g npm@2
+    - npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
+  override:
+    - make node_modules
+
+test:
+  override:
+    - make test

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "segmentio-facade": "^3.0.0"
   },
   "devDependencies": {
-    "mocha": "*",
-    "superagent": "*",
-    "segmentio-integration": "^4.0.0",
+    "batch": "~0.5.1",
     "express": "3",
-    "batch": "~0.5.1"
+    "mocha": "^3.2.0",
+    "segmentio-integration": "^4.0.0",
+    "superagent": "^3.5.1"
   }
 }

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -187,7 +187,7 @@ describe('Assertion', function(){
     it('should throw on `meta` mismatch', function(){
       var a = Assertion(segment);
       var ensure = a.ensure.bind(a, 'settings.token');
-      throws(ensure, 'validation meta mismatch {"methods":["track"]} deepEqual {}');
+      throws(ensure, 'validation meta mismatch { methods: [ \'track\' ] } deepEqual {}');
     });
 
     it('should not throw on `meta` match', function(){

--- a/test/support/index.js
+++ b/test/support/index.js
@@ -54,11 +54,16 @@ exports.send = function(msg, fn){
     type = 'text';
   }
 
-  this
+  var req = this
     .post(type + '/' + msg.type())
     .query(settings.query || msg.proxy('context.q') || 'baz=foo')
     .set('Content-Type', header)
-    .set('X-Key', settings.key)
+
+  if (settings.key) {
+    req.set('X-Key', settings.key)
+  }
+
+  req
     .send(payload)
     .end(fn);
 };


### PR DESCRIPTION
This patch updates the version of node we run our tests on. Since the
integration worker runs node 6, I figured this thing should too.

@segmentio/pizza 