### PR TITLE
assertion: add support for checking `err.status`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -567,18 +567,32 @@ Assertion.prototype.expects = function(){
 };
 
 /**
- * Assert that the integration errors with optional `msg`.
+ * Assert that the integration errors with optional error `msg` or `status`.
  *
- * @param {String} msg
+ * @param {String} [msg]
+ * @param {Number} [status]
  * @param {Function} fn
  * @api public
  */
 
-Assertion.prototype.error = function(msg, fn){
-  if (1 == arguments.length) fn = msg, msg = null;
+Assertion.prototype.error = function(){
+  var args = [].slice.call(arguments)
+  var fn = args.pop()
+
+  // parse extra optional arg
+  var msg = null
+  var status = null
+  var arg = args.pop()
+  if (typeof arg === 'string') {
+    msg = arg
+  } else if (typeof arg === 'number') {
+    status = arg
+  }
+
   this.end(function(err, responses){
     if (!err) return fn(new Error('expected integration to error'), responses);
     if (msg) return fn(utils.equals(err.message, msg));
+    if (status) return fn(utils.equals(err.status, status))
     fn();
   });
 };

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -347,6 +347,25 @@ describe('Assertion', function(){
     });
   });
 
+  describe('.error(status, fn)', function(){
+    it('should assert the error status', function(done){
+      Assertion(segment)
+        .set({ handle: true })
+        .identify({})
+        .error(400, done)
+    });
+
+    it('should throw if error status dont match', function(done){
+      Assertion(segment)
+        .set({ handle: true })
+        .identify({})
+        .error(123, function(err){
+          assert.equal(err.message, 'expected 123 but got 400')
+          done();
+        });
+    });
+  });
+
   describe('.query(obj)', function(){
     it('should assert sent query correctly', function(done){
       Assertion(segment)


### PR DESCRIPTION
This patch is part of a much larger initiative to standardize our
errors across all integrations. The ability to check the `.status` prop
on the errors we're passing around should make it extremely simple to
enforce this standard moving forward.

@segmentio/pizza 