### PR TITLE
add a queryAlmost function

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+2.1.0 / 2017-03-21
+==================
+
+  * assertion: add support for checking if request query includes specified key/value pair(s)
 
 2.1.0 / 2017-03-21
 ==================

--- a/Readme.md
+++ b/Readme.md
@@ -132,6 +132,20 @@ test.end(done);
     sendsAlmost({ baz: 'foo' }, {'ignored': ['foo']});
     // this will be fine if we send { baz: 'foo', foo: 'bar'};
 
+##### queryAmost(obj || key, value, parse)
+
+Checks to see if the request query string contained key/value (pairs). A parse function can be passed to be run on the query string value before comparison.
+
+```
+// examples
+Assertion(segment)
+  .set({ query: 'foo=baz&baz=foo' })
+  .set({ key: 'baz' })
+  .identify({})
+  .queryAlmost({ foo: 'baz' })
+  .expects(200, done);
+```
+
 ##### expects(...)
 
   Assert integration expects `...`

--- a/lib/index.js
+++ b/lib/index.js
@@ -488,6 +488,46 @@ Assertion.prototype.query = function(key, value, parse){
   return this;
 };
 
+Assertion.prototype.queryAlmost = function(key, value, parse){
+  var q = this.q[this.reqIndex] = this.q[this.reqIndex] || {};
+  var noop = function(_){ return _; };
+  var self = this;
+
+  // obj
+  if (1 == arguments.length) {
+    for (var k in key) this.queryAlmost(k, key[k]);
+    return this;
+  }
+
+  // key, value
+  q[key] = [value, parse || noop];
+
+  this.push(function(req, _, i){
+    var expect = self.q[i]
+    var query = req.req.path.split('?')[1];
+    if (!query) return new Error('expected request to include query string but no query string was found');
+
+    // actual query string
+    var actual = qs.parse(query);
+
+    // expected
+    var expected = Object
+        .keys(expect)
+        .reduce(function(_, key){
+          var arr = expect[key];
+          var expected = arr[0];
+          var parse = arr[1];
+          actual[key] = parse(actual[key]);
+          _[key] = expected;
+          return _;
+        }, {});
+    
+    return utils.contains(actual, expected);
+  });
+
+  return this;
+}
+
 /**
  * Integration sends `...`.
  *

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,7 +131,9 @@ exports.equals = function(actual, expected, ignoredKeys){
 
 exports.contains = function(actual, expected){
   for (var key in expected) {
-    if (actual[key] !== expected[key]) {
+    try {
+      assert.deepEqual(actual[key], expected[key])
+    } catch(e) {
       return exports.error('expected ' + inspect(expected)
         + ' to exist in ' + inspect(actual) + ''
         , actual

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -129,6 +129,17 @@ exports.equals = function(actual, expected, ignoredKeys){
   }
 };
 
+exports.contains = function(actual, expected){
+  for (var key in expected) {
+    if (actual[key] !== expected[key]) {
+      return exports.error('expected ' + inspect(expected)
+        + ' to exist in ' + inspect(actual) + ''
+        , actual
+        , expected);
+    }
+  }
+}
+
 /**
  * Compare `str` with `req.query`.
  *

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "segmentio-integration-tester",
   "repo": "segmentio/integration-tester",
   "description": "integration tester",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "dependencies": {
     "analytics-events": "^2.0.0",
     "clone-component": "^0.2.2",

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -464,6 +464,46 @@ describe('Assertion', function(){
     });
   });
 
+  describe('.queryAlmost(obj)', function(){
+    it('should assert sent query correctly', function(done){
+      Assertion(segment)
+        .set({ query: 'foo=baz&baz=foo' })
+        .set({ key: 'baz' })
+        .identify({})
+        .queryAlmost({ foo: 'baz' })
+        .expects(200, done);
+    })
+
+    it('should throw on no match', function(done){
+      Assertion(segment)
+        .set({ query: 'foo=baz&yolo=yup&bar=foo' })
+        .set({ key: 'baz' })
+        .identify({})
+        .queryAlmost({ foo: 'wee' })
+        .end(error('expected { foo: \'wee\' } to exist in { foo: \'baz\', yolo: \'yup\', bar: \'foo\' }', done));
+    });
+  })
+
+  describe('.queryAlmost(key, value)', function(){
+    it('should assert sent query correctly', function(done){
+      Assertion(segment)
+        .set({ query: 'foo=baz&baz=foo' })
+        .set({ key: 'baz' })
+        .identify({})
+        .queryAlmost('foo', 'baz')
+        .expects(200, done);
+    })
+
+    it('should throw on no match', function(done){
+      Assertion(segment)
+        .set({ query: 'foo=baz&yolo=yup&bar=foo' })
+        .set({ key: 'baz' })
+        .identify({})
+        .queryAlmost('foo', 'wee')
+        .end(error('expected { foo: \'wee\' } to exist in { foo: \'baz\', yolo: \'yup\', bar: \'foo\' }', done));
+    });
+  })
+
   describe('.sends(key, value)', function(){
     it('should assert sent headers correctly', function(done){
       Assertion(segment)


### PR DESCRIPTION
This pr adds a function to check to see if the request query string contained a key/value pair or object of key/value pairs. Similar to sendsAlmost.