### PR TITLE
Fix query and queryAlmost

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,8 @@
+2.1.1 / 2017-03-21
+==================
+
+  * fix issue with .query and .queryAlmost. Both were adding undefined properties to the "actual" request query parameters when checking against the expected ones.
+
 2.1.0 / 2017-03-21
 ==================
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -476,7 +476,9 @@ Assertion.prototype.query = function(key, value, parse){
         var arr = expect[key];
         var expected = arr[0];
         var parse = arr[1];
-        actual[key] = parse(actual[key]);
+        if (actual[key] !== undefined) {
+          actual[key] = parse(actual[key]);
+        }
         _[key] = expected;
         return _;
       }, {});
@@ -517,7 +519,9 @@ Assertion.prototype.queryAlmost = function(key, value, parse){
           var arr = expect[key];
           var expected = arr[0];
           var parse = arr[1];
-          actual[key] = parse(actual[key]);
+          if (actual[key] !== undefined) {
+            actual[key] = parse(actual[key]);
+          }
           _[key] = expected;
           return _;
         }, {});

--- a/lib/index.js
+++ b/lib/index.js
@@ -521,7 +521,7 @@ Assertion.prototype.queryAlmost = function(key, value, parse){
           _[key] = expected;
           return _;
         }, {});
-    
+        
     return utils.contains(actual, expected);
   });
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "segmentio-integration-tester",
   "repo": "segmentio/integration-tester",
   "description": "integration tester",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "dependencies": {
     "analytics-events": "^2.0.0",
     "clone-component": "^0.2.2",

--- a/test/assertion.js
+++ b/test/assertion.js
@@ -402,7 +402,19 @@ describe('Assertion', function(){
         .set({ key: 'baz' })
         .identify({})
         .query({ foo: 'baz' })
-        .expects(200, done);
+        .expects(200, done)
+    })
+
+    it('should not add new, undefined parameters to the actual query string', function(done){
+      Assertion(segment)
+        .set({ query: 'foo=baz' })
+        .set({ key: 'baz' })
+        .identify({})
+        .query({ totallyDifferentThing: 'foobar' })
+        .end(function(err){
+          assert.deepEqual(err.actual, { foo: 'baz' });
+          done()
+      })
     })
 
     it('should buffer arguments', function(done){
@@ -434,6 +446,18 @@ describe('Assertion', function(){
         .expects(200, done);
     });
 
+    it('should not add new, undefined parameters to the actual query string', function(done){
+      Assertion(segment)
+        .set({ query: 'foo=baz' })
+        .set({ key: 'baz' })
+        .identify({})
+        .query({ totallyDifferentThing: 'foobar' })
+        .end(function(err){
+          assert.deepEqual(err.actual, { foo: 'baz' });
+          done()
+      })
+    })
+
     it('should error on mismatch', function(done){
       Assertion(segment)
         .set({ query: 'foo=baz' })
@@ -453,6 +477,18 @@ describe('Assertion', function(){
         .query('foo', [1, 2, 3], JSON.parse)
         .expects(200, done);
     });
+
+    it('should not add new, undefined parameters to the actual query string', function(done){
+      Assertion(segment)
+        .set({ query: 'foo=baz' })
+        .set({ key: 'baz' })
+        .identify({})
+        .query({ totallyDifferentThing: 'foobar' })
+        .end(function(err){
+          assert.deepEqual(err.actual, { foo: 'baz' });
+          done()
+      })
+    })
 
     it('should error on mismatch', function(done){
       Assertion(segment)
@@ -474,6 +510,18 @@ describe('Assertion', function(){
         .expects(200, done);
     })
 
+    it('should not add new, undefined parameters to the actual query string', function(done){
+      Assertion(segment)
+        .set({ query: 'foo=baz' })
+        .set({ key: 'baz' })
+        .identify({})
+        .query({ totallyDifferentThing: 'foobar' })
+        .end(function(err){
+          assert.deepEqual(err.actual, { foo: 'baz' });
+          done()
+      })
+    })
+
     it('should throw on no match', function(done){
       Assertion(segment)
         .set({ query: 'foo=baz&yolo=yup&bar=foo' })
@@ -492,6 +540,18 @@ describe('Assertion', function(){
         .identify({})
         .queryAlmost('foo', 'baz')
         .expects(200, done);
+    })
+
+    it('should not add new, undefined parameters to the actual query string', function(done){
+      Assertion(segment)
+        .set({ query: 'foo=baz' })
+        .set({ key: 'baz' })
+        .identify({})
+        .query({ totallyDifferentThing: 'foobar' })
+        .end(function(err){
+          assert.deepEqual(err.actual, { foo: 'baz' });
+          done()
+      })
     })
 
     it('should throw on no match', function(done){


### PR DESCRIPTION
fix bug with .query and .queryAlmost. Both were adding undefined properties to the "actual" request query parameters when checking against the expected ones.